### PR TITLE
Update Dockerfile to not fail on mysql-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && apt install -y \
     nano \
     openssl \
     p7zip-full \
-    mysql-client \
+    mysql-client-* \
     redis-server
 
 ENV HASHVIEW_VERSION=v0.7.5-beta


### PR DESCRIPTION
Build was failing due to no installation candidate found for mysql-client. Using mysql-client-* instead resolves this issue.